### PR TITLE
Enhancements to BREAKPOINT macro

### DIFF
--- a/includes/debug.inc
+++ b/includes/debug.inc
@@ -493,8 +493,8 @@ BRKend	set *
 BRKlen	set BRKend-BRKserver
 BRKstart set $FFF8-BRKlen
 
-	echo "length of BRK-server :%DBRKlen"
-	echo "End of BRK-server:%HBRKend"
+	echo "length of BRK-server: %DBRKlen"
+	echo "End of BRK-server: %HBRKend"
  IF BRKstart <> BRKserver
 	echo "Possible start: %HBRKstart"
  ENDIF

--- a/macros/debug.mac
+++ b/macros/debug.mac
@@ -5,59 +5,64 @@
 * 28.8.96       new MACRO : BREAKPOINT [x[,"remote-command"]]
 
 
-                MACRO INITBRK
+  MACRO INITBRK
 
 IFD BRKuser
-                jsr InitBRK
+    jsr InitBRK
 ENDIF
-                ENDM
 
+  ENDM
 
-                MACRO BREAKPOINT
-                IFVAR \0
-                  IF \0 > $1f
-                    fail "BREAKPOINT: Number to big !"
-                  ENDIF
-                  IFVAR \1
-                    brk #(\0)|$20
-.\_0                dc.b .\_1-.\_0
-                    dc.b \1
+  MACRO BREAKPOINT
+IFD BRKuser
+  IFVAR \0
+    IF \0 > $1f
+      fail "BREAKPOINT: Number too big. Valid range #$00 to #$1f"
+    ENDIF
+    IFVAR \1
+      brk #(\0)|$20
+.\_0
+      dc.b .\_1-.\_0
+      dc.b \1
 .\_1
-                  ELSE
-                    brk #\0
-                  ENDIF
-                ELSE
-                  brk #\0
-                ENDIF
-                ENDM
+    ELSE
+      brk #\0
+    ENDIF
+  ELSE
+    brk #$ff ; Profiling breakpoint
+  ENDIF
+ENDIF
+  ENDM
 
-                MACRO DEBUG
-                php
-                pha
-                IFVAR \0
-                  SWITCH \0
-                  case "X"
-                    txa
-                  case "Y"
-                    tya
-                  elses
-                    lda \0
-                  ENDS
-                ENDIF
-;               jsr SndComLynxByte
-.\wait_         bit $fd8c
-                bpl .\wait_
-                sta $fd8d
-                pla
-                plp
-                ENDM
+  MACRO DEBUG
+  php
+  pha
+  IFVAR \0
+    SWITCH \0
+    case "X"
+      txa
+    case "Y"
+      tya
+    elses
+      lda \0
+    ENDS
+  ENDIF
+;  jsr SndComLynxByte
+.\wait_
+  bit $fd8c
+  bpl .\wait_
+  sta $fd8d
+  pla
+  plp
+  ENDM
 
-                MACRO DEBUG_WAIT
-                php
-                pha
-                stz DebugFlag
-.\wait_deb      lda DebugFlag
-                beq .\wait_deb
-                pla
-                plp
-                ENDM
+  MACRO DEBUG_WAIT
+  php
+  pha
+  stz DebugFlag
+.\wait_deb
+  lda DebugFlag
+  beq .\wait_deb
+  pla
+  plp
+  ENDM


### PR DESCRIPTION
Current implementation of the macro will always include the BRK instruction at every location where the macro is used. With the inclusion of `IFD BRKuser` the BRK instruction will only be inserted for debug builds (assuming this build does have the constant set, a production build not).

In addition, when not providing a value for the BREAKPOINT number, it currently does use the \0 value, which is not defined. Choosing for #$FF as the breakpoint number will insert a profiling breakpoint. Also, it makes it possible to use the macro for profiling breakpoints, as `BREAKPOINT #$ff` will not pass the validation for range ($00-$1f).

Fixed small typo and made error message for invalid breakpoint number range more descriptive